### PR TITLE
Corrected Basic container networking IPs

### DIFF
--- a/documents/tutorials/container-101.html
+++ b/documents/tutorials/container-101.html
@@ -380,7 +380,7 @@ vagrant@tutorial-node1:~$ ifconfig
 <p>In the <code>ifconfig</code> output, you will see that it would have created a veth <code>virtual 
 ethernet interface</code> that could look like <code>veth......</code> towards the end. More 
 importantly it is allocated an IP address from default docker bridge <code>docker0</code>, 
-likely <code>172.17.0.3</code> in this setup, and can be examined using</p>
+likely <code>172.17.0.5</code> in this setup, and can be examined using</p>
 <pre class="highlight plaintext"><code>$ docker network inspect bridge
 [
     {
@@ -449,7 +449,7 @@ vagrant@tutorial-node1:~$ docker inspect --format '{{.NetworkSettings.IPAddress}
 <pre class="highlight plaintext"><code>vagrant@tutorial-node1:~$ docker exec -it vanilla-c /bin/sh
 / # ifconfig eth0
 eth0      Link encap:Ethernet  HWaddr 02:42:AC:11:00:03  
-          inet addr:172.17.0.3  Bcast:0.0.0.0  Mask:255.255.0.0
+          inet addr:172.17.0.5  Bcast:0.0.0.0  Mask:255.255.0.0
           inet6 addr: fe80::42:acff:fe11:3%32577/64 Scope:Link
           UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
           RX packets:8 errors:0 dropped:0 overruns:0 frame:0

--- a/websrc/source/documents/tutorials/container-101.md
+++ b/websrc/source/documents/tutorials/container-101.md
@@ -181,7 +181,7 @@ vagrant@tutorial-node1:~$ ifconfig
 In the `ifconfig` output, you will see that it would have created a veth `virtual 
 ethernet interface` that could look like `veth......` towards the end. More 
 importantly it is allocated an IP address from default docker bridge `docker0`, 
-likely `172.17.0.3` in this setup, and can be examined using
+likely `172.17.0.5` in this setup, and can be examined using
 
 ```
 $ docker network inspect bridge
@@ -255,7 +255,7 @@ The other pair of veth interface is put into the container with the name `eth0`
 vagrant@tutorial-node1:~$ docker exec -it vanilla-c /bin/sh
 / # ifconfig eth0
 eth0      Link encap:Ethernet  HWaddr 02:42:AC:11:00:03  
-          inet addr:172.17.0.3  Bcast:0.0.0.0  Mask:255.255.0.0
+          inet addr:172.17.0.5  Bcast:0.0.0.0  Mask:255.255.0.0
           inet6 addr: fe80::42:acff:fe11:3%32577/64 Scope:Link
           UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
           RX packets:8 errors:0 dropped:0 overruns:0 frame:0


### PR DESCRIPTION
I believe we want to reference `vanilla-c`'s IP not the IP of the
`swarm-manager`.

Fixes: #100