### PR TITLE
removed old links from sidebar

### DIFF
--- a/documents/admin/createNodes.html
+++ b/documents/admin/createNodes.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/admin/createTenant.html
+++ b/documents/admin/createTenant.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/admin/index.html
+++ b/documents/admin/index.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/admin/manageAuthorizations.html
+++ b/documents/admin/manageAuthorizations.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/admin/manageLDAP.html
+++ b/documents/admin/manageLDAP.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/admin/manageNetworks.html
+++ b/documents/admin/manageNetworks.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/admin/manageUsers.html
+++ b/documents/admin/manageUsers.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/admin/portinfo.html
+++ b/documents/admin/portinfo.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/demos/index.html
+++ b/documents/demos/index.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/gettingStarted/index.html
+++ b/documents/gettingStarted/index.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/gettingStarted/networking/aci.html
+++ b/documents/gettingStarted/networking/aci.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/gettingStarted/networking/bgp.html
+++ b/documents/gettingStarted/networking/bgp.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/gettingStarted/networking/index.html
+++ b/documents/gettingStarted/networking/index.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/gettingStarted/networking/install-k8s.html
+++ b/documents/gettingStarted/networking/install-k8s.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/gettingStarted/networking/install-swarm.html
+++ b/documents/gettingStarted/networking/install-swarm.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/gettingStarted/networking/installation.html
+++ b/documents/gettingStarted/networking/installation.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/gettingStarted/networking/k8s.html
+++ b/documents/gettingStarted/networking/k8s.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/gettingStarted/networking/quickstart.html
+++ b/documents/gettingStarted/networking/quickstart.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/gettingStarted/networking/swarm.html
+++ b/documents/gettingStarted/networking/swarm.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/gettingStarted/networking/vagrant.html
+++ b/documents/gettingStarted/networking/vagrant.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/index.html
+++ b/documents/index.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>
@@ -257,7 +252,7 @@ GitHub</a></li>
 <ul>
 <li><a href="/documents/tutorials">Tutorials</a>
 </li>
-<li><a href="/documents/demos">Demostration Videos</a>
+<li><a href="/documents/demos">Demonstration Videos</a>
 </li>
 <li><a href="/documents/talks">Community Talks</a>
 </li>
@@ -267,10 +262,6 @@ GitHub</a></li>
 <p>Some short but practical implementations to help you get started.</p>
 
 <ul>
-<li><a href="/documents/samples">Docker Compose Examples</a>
-</li>
-<li><a href="/documents/samples">Kubernetes Examples</a>
-</li>
 <li><a href="/documents/samples">Multicast Examples</a>
 </li>
 </ul>

--- a/documents/networking/aci_ug.html
+++ b/documents/networking/aci_ug.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/networking/bgp.html
+++ b/documents/networking/bgp.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/networking/concepts.html
+++ b/documents/networking/concepts.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/networking/features.html
+++ b/documents/networking/features.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/networking/index.html
+++ b/documents/networking/index.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/networking/ipam.html
+++ b/documents/networking/ipam.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/networking/ipv6.html
+++ b/documents/networking/ipv6.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/networking/l2-vlan.html
+++ b/documents/networking/l2-vlan.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/networking/physical-networks.html
+++ b/documents/networking/physical-networks.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/networking/policies.html
+++ b/documents/networking/policies.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/networking/services.html
+++ b/documents/networking/services.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/openshift/index.html
+++ b/documents/openshift/index.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/reference/netctlcli.html
+++ b/documents/reference/netctlcli.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/releasenotes/beta.html
+++ b/documents/releasenotes/beta.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/samples/index.html
+++ b/documents/samples/index.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li class="active">
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li class="active">
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/samples/mcast.html
+++ b/documents/samples/mcast.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li class="active">
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li class="active">
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li class="active">
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/talks/index.html
+++ b/documents/talks/index.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/tutorials/container-101.html
+++ b/documents/tutorials/container-101.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/tutorials/contiv-compose.html
+++ b/documents/tutorials/contiv-compose.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/documents/tutorials/index.html
+++ b/documents/tutorials/index.html
@@ -196,11 +196,6 @@ GitHub</a></li>
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>

--- a/websrc/source/documents/index.md
+++ b/websrc/source/documents/index.md
@@ -21,18 +21,16 @@ Information on getting started and using Contiv for Container networking:
 
 - [API](/documents/api/contiv.html)
 - [CLI](/documents/reference/netctlcli.html)
-- [ContivModel Client] (https://godoc.org/github.com/contiv/contivmodel/client)
+- [ContivModel Client](https://godoc.org/github.com/contiv/contivmodel/client)
 
 ### Tutorials and Talks
 - [Tutorials](/documents/tutorials)
-- [Demostration Videos](/documents/demos)
+- [Demonstration Videos](/documents/demos)
 - [Community Talks](/documents/talks)
 
 ### Examples
 Some short but practical implementations to help you get started.
 
-- [Docker Compose Examples](/documents/samples)
-- [Kubernetes Examples](/documents/samples)
 - [Multicast Examples](/documents/samples)
 
 

--- a/websrc/source/layouts/documents.erb
+++ b/websrc/source/layouts/documents.erb
@@ -151,11 +151,6 @@
 			<hr><p>
 			<h3>Examples</h3>
 				<ul class="nav">
-						<li<%= sidebar_current("samples") %>>
-							<a href="/documents/samples/index.html">Docker Compose Examples</a>
-						</li>
-						<li<%= sidebar_current("samples") %>>
-							<a href="/documents/samples/index.html">Kubernetes Examples</a>
 						</li>
 						<li<%= sidebar_current("samples-mcast") %>>
 							<a href="/documents/samples/mcast.html">Multicast Examples</a>


### PR DESCRIPTION
#93 the examples were never docker or kubernetes oriented, just Multicast and Nomad. With Nomad gone, only multicast remains