### PR TITLE
Update Contiv Openshift docs (include L3 VXLAN examples, OSE v3.6)

### DIFF
--- a/documents/openshift/index.html
+++ b/documents/openshift/index.html
@@ -228,57 +228,138 @@ GitHub</a></li>
 		</div>  
 		<div id="main-content" class="col-sm-9 col-md-9 col-xs-12" role="main">
 			<div class="bs-docs-section">
-					<h1>Contiv support for OpenShift</h1>
+					<h1>Using Contiv with OpenShift</h1>
 <p>Contiv is a certified plugin for Openshift (both Openshift Origin and Openshift Enterprise/ Red Hat Container Platform).</p>
-<p><strong>Note:</strong> This feature is currently in Alpha status; refer to the supported features list and community support details below. If you have questions, <a href="https://contiv.herokuapp.com/">sign up for Slack</a> and ask us on our <a href="https://contiv.slack.com">Slack channel</a>. Contact your support representatives from Red Hat and Cisco for details on the enterprise support plan and timelines.</p>
+<p><strong>Note:</strong> If you have further questions, <a href="https://contiv.herokuapp.com/">sign up for Slack</a> and ask us on our <a href="https://contiv.slack.com">Slack channel</a>. Contact your support representatives from Red Hat and Cisco for details on the enterprise support plan and timelines.</p>
 
 <h2>Using Contiv and OpenShift</h2>
-<p>The Contiv installer is integrated with the standard <a href="https://docs.openshift.org/latest/install_config/install/advanced_install.html">Openshift Ansible-based installer</a> for both Openshift Origin and Openshift Enterprise (Red Hat Container Platform). In order to install and use Openshift with Contiv, the basic procedure is to install Openshift using its Ansible installer with its standard Openshift installation playbook and set some ansible inventory configuration parameters such that Contiv is also installed during the Openshift installation itself. This will result in a single combined installation process which results in both Openshift and Contiv being installed via Ansible in a single step.  In order to run this combined playbook,</p>
+<p>An ansible based Contiv installer is pre-integrated with the standard Openshift Ansible-based installers for both <a href="https://docs.openshift.org/latest/install_config/install/advanced_install.html">Openshift Origin</a> and <a href="https://docs.openshift.com/container-platform/3.6/install_config/install/advanced_install.html">Openshift Enterprise (Red Hat Container Platform)</a>. Simply using Openshift`s own Ansible based installer (with some configuration/ inventory settings as shown in examples below) will result in a single combined installation process which results in both Openshift and Contiv being installed via Ansible in a single step.</p>
 
-<h2>Current community supported configurations, features</h2>
+<h2>Current community supported configurations, features when using Contiv with Openshift</h2>
 
 <ol>
-<li>Openshift Origin (version 1.3.0 or later)
+<li>Openshift Origin (version 3.6 or later)
 </li>
-<li>Openshift Enterprise/ Red Hat Container Platform (version 3.5.0 or later). 
-</li>
-<li>Openshift Enterprise 3.4.0 supported via install from ansible source (3.4 Openshift Ansible yum package not supported).
+<li>Openshift Enterprise/ Red Hat Container Platform (version 3.6 or later). 
 </li>
 <li>All standard Openshift features including Openshift Registry, Openshift Router (with default HAProxy load balancer)
 </li>
-<li>Contiv 1.0.0 release
+<li>Contiv 1.1.1 release (automatically pre-installed with Openshift version 3.6 or later)
 </li>
-<li>Bare metal server deployments only (Centos7 or Rhel7)
+<li>Bare metal or VM based deployments
 </li>
-<li>Contiv L2 VLAN networking mode only
+<li>Hosts must run Centos 7.x or RHEL 7.x as required by Openshift. Contiv currently does not support RHEL 7.x Atomic as the host OS.
+</li>
+<li>Contiv may currently be used in either L3 (no BGP) VXLAN mode, L2 VLAN mode or ACI mode with Openshift. Use of Contiv in L3 BGP mode with Openshift is currently in experimental status and will be officially supported in future releases.
+</li>
+<li>Subject to all standard common Openshift deployment requirements, <a href="https://docs.openshift.com/container-platform/3.6/install_config/install/prerequisites.html">pre-requisites, and host preparation listed on the Openshift documentation pages</a> (for example ansible 2.3.0 or later is required for Openshift v3.6 installer and the NetworkManager package is required to be installed on the hosts)
+</li>
+<li>Openshift Ansible installer must currently be executed in non-containerized mode when also installing Contiv (ie rpm based Openshift install). Support for the containerized Openshift install with Contiv will be an option in a future release.
 </li>
 </ol>
-<p>Notes:
-1. Currently we recommend inquiring on the <a href="https://contiv.slack.com">Contiv community slack channel</a> for technical support and questions for initial trials and POCs. Please contact your Cisco and Red Hat support representatives for exact official status and timelines for enterprise level support options.</p>
+<p><strong>Important Note:</strong></p>
 
 <ol>
-<li>Contiv installer is available in yum packages for Openshift enterprise from 3.5 onwards. For Openshift Enterprise 3.4 and for Openshift Origin 1.3 and 1.4, the Contiv installer is available in the Openshift Ansible github repo master branch and hence may be installed by pulling the Openshift Ansible installer from github directly. An example of this installation is provided below.
+<li>The currently recommended combination is to use Openshift (Origin or Enterprise) version 3.6 or later and Contiv in L3 VXLAN mode without BGP. Earlier versions of Openshift or other networking modes of Contiv can also work but will require some additional manual configuration changes to the physical networking layer and/or the Openshift/ kubernetes layer. Note that the Openshift 3.6 Ansible installer can also be used to deploy Openshift packages from earlier releases by simply setting the openshift_release configuration variable in the ansible installer inventory file as shown in the examples below.<br>
 </li>
 </ol>
 
-<h2>Installation example for Openshift + Contiv</h2>
-<p>In this example, we shall illustrate a single combined installation of Openshift and Contiv together and shall use the Openshift Ansible directly from github to do this. In this example, we have an Ansible installer/ management node installing Openshift + Contiv onto 4 bare metal servers resulting in 1 Master + 3 Nodes in the resulting Openshift cluster.</p>
+<h2>Installation example for Openshift + Contiv (L3 VXLAN mode use case)</h2>
+<p>In this example, we shall illustrate a single combined installation of Openshift and Contiv together and shall use Contiv in L3 VXLAN mode (which is currently the recommended mode for Contiv). This example deploys these on top of a cluster of Virtual Machines (that have been pre-created on some standard IaaS service such as Openstack for example) but this combination is also supported when the cluster hosts are bare metal machines.</p>
 
 <ol>
-<li>Clone the standard Openshift Ansible repo directly (git clone <a href="https://github.com/openshift/openshift-ansible.git">https://github.com/openshift/openshift-ansible.git</a>)
+<li>Clone the standard Openshift Ansible repo directly from a supported release branch<br>
+(<em>git clone -b release-3.6 <a href="https://github.com/openshift/openshift-ansible.git">https://github.com/openshift/openshift-ansible.git</a></em>)<br>
+<strong>Note:</strong> Alternately the Openshift Ansible can also be installed via yum/ RPM (refer to Openshift documentation for details on using the <em>atomic-openshift-utils</em> rpm package for this)  or git cloned from the master branch, instead of the release-3.6 branch, from the same repo.
 </li>
-<li>Edit the ansible inventory file to match the desired master and node topology and IP addresses of your target bare metal machines. The Openshift documentation (see for example <a href="https://docs.openshift.org/latest/install_config/install/advanced_install.html">here</a> and <a href="https://docs.openshift.com/container-platform/3.4/install_config/install/advanced_install.html">here</a>) has examples of Ansible inventory files for typical cluster deployments.
+<li>Edit the ansible inventory file to match the desired master and node topology and IP addresses of your target bare metal machines. The Openshift documentation (see for example <a href="https://docs.openshift.org/latest/install_config/install/advanced_install.html">here</a> and <a href="https://docs.openshift.com/container-platform/3.6/install_config/install/advanced_install.html">here</a>) has examples of Ansible inventory files for typical cluster deployments.
+</li>
+<li>Edit the ansible inventory file to use Contiv as the networking plugin instead of the default Openshift SDN and set additional configuration parameters to match your cluster topology and contiv network settings. (an example of the Contiv configuration parameters is provided below).
+</li>
+<li>Run the Ansible playbook for the BYO machines case<br>
+<em>ansible-playbook -i your_inventory_file ./playbooks/BYO/config.yml</em>
+</li>
+</ol>
+
+<h2>Example Ansible inventory file Openshift Origin + Contiv (L3 VXLAN mode) on VMs</h2>
+<p>Please refer to the <a href="https://docs.openshift.org/latest/install_config/install/advanced_install.html">Openshift documentation</a> for full details on Openshift configuration. The example ansible inventory file here is to install a cluster of 3 Openshift Origin v3.6 nodes running Contiv in L3 VXLAN mode and deployed on top of 3 VMs. Each of these VMs has a private IP and a floating IP (in Openstack terminology). In the example below, the addresses in the range 184.94.x.x are the floating IP addresses of the cluster VMs and the addresses in the range 10.104.x.x are the private IP addresses of the cluster VMs. Please modify these to match the private IP and floating IP addresses in your set of VMs accordingly before running the playbook.</p>
+<pre class="highlight plaintext"><code># Create an OSEv3 group that contains the masters and nodes groups
+[OSEv3:children]
+masters
+nodes
+
+# Set variables common for all OSEv3 hosts
+[OSEv3:vars]
+# SSH user, this user should allow ssh based auth without requiring a password
+ansible_ssh_user=cloud
+
+# Temporarily disable resource checks to allow test deployment on low resource hosts/ VMs 
+openshift_disable_check=disk_availability,memory_availability,docker_storage
+
+# If ansible_ssh_user is not root, ansible_become must be set to true
+ansible_become=true
+
+deployment_type=origin
+
+# To try other release versions, change this variable (v3.6 is currently the recommended release)
+#openshift_release=v1.5
+openshift_release=v3.6
+
+os_firewall_use_firewalld=false
+
+openshift_use_openshift_sdn=False
+openshift_use_contiv=True
+os_sdn_network_plugin_name='cni'
+
+# Use the following contiv settings for now. 
+# In upcoming versions of the installer, these settings will be automatically defaulted and hence not needed to be configured explicitly here
+netplugin_interface=eth0
+netmaster_interface=eth0
+netplugin_fwd_mode=routing
+contiv_encap_mode=vxlan
+contiv_default_network_tag=1000
+
+# host group for masters
+[masters]
+184.94.251.61 openshift_public_hostname=184.94.251.61
+
+# host group for nodes, includes region info
+[nodes]
+184.94.251.61 netplugin_ctrl_ip=10.104.1.80 openshift_public_hostname=184.94.251.61 openshift_node_labels="{'region': 'infra', 'zone': 'default'}" openshift_schedulable=true
+184.94.253.153 netplugin_ctrl_ip=10.104.1.83 openshift_public_hostname=184.94.253.153 openshift_node_labels="{'region': 'primary', 'zone': 'east'}" openshift_schedulable=true
+184.94.251.16 netplugin_ctrl_ip=10.104.1.84 openshift_public_hostname=184.94.251.16 openshift_node_labels="{'region': 'primary', 'zone': 'west'}" openshift_schedulable=true
+</code></pre>
+
+<h2>Cleaning up/ uninstalling an Openshift + Contiv cluster</h2>
+<p>You may sometimes need to do a clean rebuild of an Openshift + Contiv cluster. This may be because of an error in a prior deployment attempt that may have left some unknown/ partial state on the host machines or when you are switching from another network plugin type to Contiv for example. In all such cases, it is strongly recommended 
+clean up the cluster hosts and remove any left over state that may exist on the hosts. Without proper cleanup/ uninstall of prior state, it is possible to have errors in new attempts to deploy Openshift + Contiv on the same hosts. In order to uninstall Contiv and Openshift, run the following two ansible playbooks</p>
+
+<ol>
+<li><em>ansible-playbook -i your_inventory_file ./playbooks/adhoc/contiv/delete_contiv.yml</em>
+</li>
+<li><em>ansible-playbook -i your_inventory_file ./playbooks/adhoc/uninstall.yml</em>
+</li>
+</ol>
+<p>After these steps, the hosts will be cleaned up from any left over state and a new Openshift + Contiv cluster may safely be installed on these hosts using an install process such as described in the earlier example.</p>
+
+<h2>Installation example for Openshift + Contiv (L2 VLAN mode use case)</h2>
+<p>In this second example, we shall illustrate a single combined installation of Openshift and Contiv together and shall use the Openshift Ansible directly from github to do this. In this example, we have an Ansible installer/ management node installing Openshift + Contiv onto 4 bare metal servers resulting in 1 Master + 3 Nodes in the resulting Openshift cluster.</p>
+
+<ol>
+<li>Clone the standard Openshift Ansible repo directly (<em>git clone <a href="https://github.com/openshift/openshift-ansible.git">https://github.com/openshift/openshift-ansible.git</a></em>)
+</li>
+<li>Edit the ansible inventory file to match the desired master and node topology and IP addresses of your target bare metal machines. The Openshift documentation (see for example <a href="https://docs.openshift.org/latest/install_config/install/advanced_install.html">here</a> and <a href="https://docs.openshift.com/container-platform/3.6/install_config/install/advanced_install.html">here</a>) has examples of Ansible inventory files for typical cluster deployments.
 </li>
 <li>Edit the ansible inventory file to use Contiv as the networking plugin instead of the default Openshift SDN and set additional configuration parameters to match your cluster topology and contiv network settings. (an example of the Contiv configuration parameters is in the following section).
 </li>
-<li>Run the Ansible playbook for the BYO machines case (i.e. &quot;ansible-playbook -i <your_inventory_file> ./playbooks/BYO/config.yml&quot;).
+<li>Run the Ansible playbook for the BYO machines case<br>
+<em>ansible-playbook -i your_inventory_file ./playbooks/BYO/config.yml</em>
 </li>
 </ol>
 <p>Thats it, you now have a running Openshift cluster which uses Contiv as its networking layer.</p>
-<p><strong>Note:</strong> Ansible 2.2.0 or later is recommended for deploying via the Openshift + Contiv Ansible playbook.</p>
 
-<h2>Example Ansible inventory file for deploying Openshift Origin + Contiv</h2>
-<p>Please refer to the <a href="https://docs.openshift.org/latest/install_config/install/advanced_install.html">Openshift documentation</a> for full details on Openshift configuration. Here we list an example of adapting one of the inventory files from the Openshift documentation examples to substitute Contiv in place of the default Openshift SDN. This example illustrates set up for an Openshift Origin cluster running version 1.4.1. Contiv is enabled via the variable &quot;openshift_use_contiv&quot; and by setting &quot;openshift_use_openshift_sdn&quot; to &quot;false&quot; as well as other parameters as shown below. &quot;netplugin_interface&quot; is the contiv data plane vlan interface, &quot;netmaster_interface&quot; is the control plane interface, &quot;netplugin_fwd_interface&quot; set to &quot;bridge&quot; sets Contiv in L2 vlan mode. The default subnet (for pod IPs), default gateway and VLAN tag are set via  &quot;contiv_default_subnet&quot;, &quot;contiv_default_gw&quot; and &quot;contiv_default_network_tag&quot;.  When this playbook is executed, a default container network (called &quot;default-net&quot;) will also be set up and will use these parameters. Note that since this is the L2 VLAN mode of Contiv, the data plane VLANs and default gateway will also need to be setup externally in the physical network that the cluster uses.</p>
+<h2>Example Ansible inventory file for deploying Openshift Origin + Contiv (L2 VLAN mode) on Bare Metal servers</h2>
+<p>Please refer to the <a href="https://docs.openshift.org/latest/install_config/install/advanced_install.html">Openshift documentation</a> for full details on Openshift configuration. Here we list an example of adapting one of the inventory files from the Openshift documentation examples to substitute Contiv in place of the default Openshift SDN. This example illustrates set up for an Openshift Origin cluster running version 3.6. Contiv is enabled via the variable &quot;openshift_use_contiv&quot; and by setting &quot;openshift_use_openshift_sdn&quot; to &quot;false&quot; as well as other parameters as shown below. &quot;netplugin_interface&quot; is the contiv data plane vlan interface, &quot;netmaster_interface&quot; is the control plane interface, &quot;netplugin_fwd_interface&quot; set to &quot;bridge&quot; sets Contiv in L2 vlan mode. The default subnet (for pod IPs), default gateway and VLAN tag are set via  &quot;contiv_default_subnet&quot;, &quot;contiv_default_gw&quot; and &quot;contiv_default_network_tag&quot;.  When this playbook is executed, a default container network (called &quot;default-net&quot;) will also be set up and will use these parameters. Note that since this is the L2 VLAN mode of Contiv, the data plane VLANs and default gateway will also need to be setup externally in the physical network that the cluster uses.</p>
 <pre class="highlight plaintext"><code># Create an OSEv3 group that contains the masters and nodes groups
 [OSEv3:children]
 masters
@@ -294,8 +375,7 @@ ansible_become=true
 
 deployment_type=origin
 
-openshift_version=1.4.1
-openshift_release=v1.4
+openshift_release=v3.6
 
 os_firewall_use_firewalld=false
 
@@ -310,6 +390,7 @@ contiv_default_subnet="29.70.0.0/24"
 contiv_default_gw="29.70.0.1"
 contiv_default_network_tag="2970"
 
+# rest of the file similar to the example listed above for the L3 VXLAN mode case
 </code></pre>
 
 	<hr>

--- a/documents/tutorials/prometheus-tutorial.html
+++ b/documents/tutorials/prometheus-tutorial.html
@@ -243,11 +243,11 @@ GitHub</a></li>
 <p>This walks through the setup for Prometheus and Grafana and an example that may be useful for troubleshooting connectivity issues within your cluster.</p>
 
 <h3><a name="setup"></a> Setup</h3>
-<p>Please finish the <a href="https://contiv.github.io/documents/tutorials/networking-kubernetes-16.html">Container Networking Tutorial</a>, but do not clean up your cluster.</p>
+<p>Please finish the <a href="/documents/tutorials/networking-kubernetes-16.html">Container Networking Tutorial</a>, but do not clean up your cluster.</p>
 <p>In order to install Prometheus and Grafana, please follow these steps.</p>
 <pre class="highlight plaintext"><code>[vagrant@kubeadm-master ~]$ cd contiv-*
 [vagrant@kubeadm-master contiv-1.1.1]$  cd install/k8s/k8s1.6
-[vagrant@kubeadm-master k8s1.6]$ sudo bash
+[vagrant@kubeadm-master k8s1.6]$ sudo -i
 [root@kubeadm-master k8s1.6]# cp prometheus.yml /var/contiv/prometheus.yml
 [root@kubeadm-master k8s1.6]# exit
 exit
@@ -271,12 +271,12 @@ service "grafana" created
 
 <h3><a name="ch1"></a> Chapter 1: Prometheus and Grafana</h3>
 <p>Prometheus is an open source monitoring platform that is useful for visualizing time series data. You can monitor and get alerts for your cluster through Prometheus. You can find out more about Prometheus <a href="https://prometheus.io/">here</a>.</p>
-<p>Grafana is an open source data visualization platform which further enhances the user experience. In this tutorial you will learn how Grafana can directly ingest data from Prometheus and some useful queries. For more information on Grafana, click <a href="https://grafana.com/">here</a>.</p>
+<p>Grafana is an open source data visualization platform which further enhances the user experience. In this tutorial, you will learn how Grafana can visualize the data stored in Prometheus and how to run some useful queries in the Grafana dashboard. For more information on Grafana, click <a href="https://grafana.com/">here</a>.</p>
 <p>Let&#39;s explore Prometheus and Grafana.</p>
 <p>Prometheus and Grafana are running as NodePorts which are exposed on the host IP. Since they are both configured to run on the master node, let&#39;s find out the IP of the master node.</p>
 <pre class="highlight plaintext"><code>[vagrant@kubeadm-master ~]$ kubectl describe nodes kubeadm-master
 </code></pre>
-<p>We can see that it&#39;s IP is 192.168.2.54.</p>
+<p>We can see that its IP is 192.168.2.54.</p>
 <p>We can also find out what port Prometheus is exposed at.</p>
 <pre class="highlight plaintext"><code>[vagrant@kubeadm-master ~]$ kubectl get svc -n kube-system
 NAME         CLUSTER-IP       EXTERNAL-IP   PORT(S)          AGE
@@ -288,15 +288,15 @@ prometheus   10.101.101.193   &lt;nodes&gt;       9090:32700/TCP   25m
 <p>Let&#39;s check and make sure that Prometheus is able to fetch data from all the nodes. At the top click on Status and in the drop down menu click on Targets. You should see a list of targets and that they are <code>UP</code> and green. If it says <code>UNKNOWN</code> it is likely because the environment or prometheus is still configuring.</p>
 <p>Go back to Graph from the top tool bar. Click on the drop down menu that says <code>-insert metric at cursor-</code> and pick any metric. Then click on <code>Execute</code> and <code>Graph</code> right below the <code>Execute</code> button.</p>
 <p>Now let&#39;s move to Grafana.</p>
-<p>Grafana is exposed at port 32701, so let&#39;s navigate to <a href="http://192.168.2.54:32701">http://192.168.2.54:32701</a> in our browser. The Grafana UI will open up and prompt you for a username and password. Username is &quot;admin&quot; and password is &quot;admin&quot;. We will be working with Grafana for the remainder of this tutorial because it&#39;s UI is more user friendly.</p>
-<p>After you have logged in, you will see an option to <code>Add data source</code>. Click on that. Fill out the information as show in the following screenshot.</p>
+<p>Grafana is exposed at port 32701, so let&#39;s navigate to <a href="http://192.168.2.54:32701">http://192.168.2.54:32701</a> in our browser. The Grafana UI will open up and prompt you for a username and password. Username is &quot;admin&quot; and password is &quot;admin&quot;. We will be working with Grafana for the remainder of this tutorial because its UI is more user friendly.</p>
+<p>After you have logged in, you will see an option to <code>Add data source</code>. Click on that. Fill out the information as shown in the following screenshot.</p>
 <p><img alt="Add Data Source" src="/documents/tutorials/add_data_source-d28908f3.png"/></p>
 <p>Click on <code>Add</code> and <code>Save &amp; Test</code>.</p>
 <p>Click on the Grafana logo in the top left of the screen and go to Dashboard and click on <code>New</code>.
 Click on <code>Graph</code>. Click on &quot;Panel Title&quot; and then click on &quot;Edit&quot;.</p>
 
 <h3><a name="ch2"></a> Chapter 2: Basic Ping Example</h3>
-<p>Now go back to your terminal which has the cluster running. You should already have a <code>contiv-net</code> setup as part of the Networking Tutorial as well as the <code>contiv-c1</code> and <code>contiv-c2</code> pods up and running.</p>
+<p>Now go back to your terminal which has the cluster running. You should already have a <code>contiv-net</code> network setup as part of the Networking Tutorial as well as the <code>contiv-c1</code> and <code>contiv-c2</code> pods up and running.</p>
 <pre class="highlight plaintext"><code>[vagrant@kubeadm-master ~]$ netctl net ls
 Tenant   Network      Nw Type  Encap type  Packet tag  Subnet        Gateway    IPv6Subnet  IPv6Gateway  Cfgd Tag
 ------   -------      -------  ----------  ----------  -------       ------     ----------  -----------  ---------
@@ -324,6 +324,8 @@ tx_packets{containerName="contiv-c2"}
 </code></pre>
 <p>Now if we go back to the Grafana Dashboard, we should see that the number of packets transmitted increases, so our basic ping works.</p>
 <p><img alt="Basic Ping" src="/documents/tutorials/basic_ping-42d7791e.png"/></p>
+<p>The way the data is displayed shows a monotonically increasing counter. This may not be the most ideal way to display your data, in which case you can also graph deltas. <code>idelta()</code> is a query function that takes a range vector of the metric you want to graph. A range vector is a list of datapoints over a period of time. For example, you can graph the received bytes over a one day span with the following query.</p>
+<p><code>idelta(rx_packets{containerName=&quot;contiv-c1&quot;}[1d])</code></p>
 <p>As you go through the rest of the Networking and Policy Tutorials, you can keep experimenting with different queries and viewing graphs on Grafana.</p>
 
 <h3><a name="resources"></a> Resources</h3>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,301 +2,301 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>http://contiv.io/articles/2016/03/06/scaling-microservices.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/articles/2016/05/17/onug-contiv-award.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/articles/2016/07/13/dockercon-talk.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/articles/</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/admin/createNodes.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/admin/createTenant.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/admin/</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/admin/manageAuthorizations.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/admin/manageLDAP.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/admin/manageNetworks.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/admin/manageUsers.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/api/contiv.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/api/wip.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/community/</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/demos/</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/gettingStarted/</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/networking/aci_setup.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/networking/aci_ug.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/networking/bgp.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/networking/concepts.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/networking/features.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/networking/</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/networking/ipam.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/networking/ipv6.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/networking/l2-vlan.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/networking/physical-networks.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/networking/policies.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/networking/portinfo.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/networking/services.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/openshift/</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/reference/netctlcli.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/releasenotes/beta.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/releasenotes/v10x.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/releasenotes/v11x.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/samples/</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/samples/mcast.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/support/supportmatrix/</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/support/supportmatrix/v10x.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/support/supportmatrix/v11x.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/talks/</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/tutorials/container-101.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/tutorials/contiv-compose.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/tutorials/contiv-policy-kubernetes-16.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/tutorials/contiv-policy.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/tutorials/</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/tutorials/networking-kubernetes-16.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/tutorials/prometheus-tutorial.html</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/support/</loc>
-    <lastmod>2017-08-10T00:00:00+00:00</lastmod>
+    <lastmod>2017-08-16T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/websrc/source/documents/openshift/index.md
+++ b/websrc/source/documents/openshift/index.md
@@ -6,47 +6,119 @@ description: |-
   Contiv and OpenShift
 ---
 
-#Contiv support for OpenShift
+#Using Contiv with OpenShift
 
 Contiv is a certified plugin for Openshift (both Openshift Origin and Openshift Enterprise/ Red Hat Container Platform).  
 
-**Note:** This feature is currently in Alpha status; refer to the supported features list and community support details below. If you have questions, [sign up for Slack](https://contiv.herokuapp.com/) and ask us on our [Slack channel](https://contiv.slack.com). Contact your support representatives from Red Hat and Cisco for details on the enterprise support plan and timelines.
+**Note:** If you have further questions, [sign up for Slack](https://contiv.herokuapp.com/) and ask us on our [Slack channel](https://contiv.slack.com). Contact your support representatives from Red Hat and Cisco for details on the enterprise support plan and timelines.
 
 ##Using Contiv and OpenShift
 
-The Contiv installer is integrated with the standard [Openshift Ansible-based installer](https://docs.openshift.org/latest/install_config/install/advanced_install.html) for both Openshift Origin and Openshift Enterprise (Red Hat Container Platform). In order to install and use Openshift with Contiv, the basic procedure is to install Openshift using its Ansible installer with its standard Openshift installation playbook and set some ansible inventory configuration parameters such that Contiv is also installed during the Openshift installation itself. This will result in a single combined installation process which results in both Openshift and Contiv being installed via Ansible in a single step.  In order to run this combined playbook,
+An ansible based Contiv installer is pre-integrated with the standard Openshift Ansible-based installers for both [Openshift Origin](https://docs.openshift.org/latest/install_config/install/advanced_install.html) and [Openshift Enterprise (Red Hat Container Platform)](https://docs.openshift.com/container-platform/3.6/install_config/install/advanced_install.html). Simply using Openshift\`s own Ansible based installer (with some configuration/ inventory settings as shown in examples below) will result in a single combined installation process which results in both Openshift and Contiv being installed via Ansible in a single step.
 
-##Current community supported configurations, features
+##Current community supported configurations, features when using Contiv with Openshift
 
-1. Openshift Origin (version 1.3.0 or later)
-2. Openshift Enterprise/ Red Hat Container Platform (version 3.5.0 or later). 
-3. Openshift Enterprise 3.4.0 supported via install from ansible source (3.4 Openshift Ansible yum package not supported).
-4. All standard Openshift features including Openshift Registry, Openshift Router (with default HAProxy load balancer)
-5. Contiv 1.0.0 release
-6. Bare metal server deployments only (Centos7 or Rhel7)
-7. Contiv L2 VLAN networking mode only
+1. Openshift Origin (version 3.6 or later)
+2. Openshift Enterprise/ Red Hat Container Platform (version 3.6 or later). 
+3. All standard Openshift features including Openshift Registry, Openshift Router (with default HAProxy load balancer)
+4. Contiv 1.1.1 release (automatically pre-installed with Openshift version 3.6 or later)
+5. Bare metal or VM based deployments
+6. Hosts must run Centos 7.x or RHEL 7.x as required by Openshift. Contiv currently does not support RHEL 7.x Atomic as the host OS.
+7. Contiv may currently be used in either L3 (no BGP) VXLAN mode, L2 VLAN mode or ACI mode with Openshift. Use of Contiv in L3 BGP mode with Openshift is currently in experimental status and will be officially supported in future releases.
+8. Subject to all standard common Openshift deployment requirements, [pre-requisites, and host preparation listed on the Openshift documentation pages](https://docs.openshift.com/container-platform/3.6/install_config/install/prerequisites.html) (for example ansible 2.3.0 or later is required for Openshift v3.6 installer and the NetworkManager package is required to be installed on the hosts)
+9. Openshift Ansible installer must currently be executed in non-containerized mode when also installing Contiv (ie rpm based Openshift install). Support for the containerized Openshift install with Contiv will be an option in a future release.
 
-Notes:
-1. Currently we recommend inquiring on the [Contiv community slack channel](https://contiv.slack.com) for technical support and questions for initial trials and POCs. Please contact your Cisco and Red Hat support representatives for exact official status and timelines for enterprise level support options.
+**Important Note:**
 
-2. Contiv installer is available in yum packages for Openshift enterprise from 3.5 onwards. For Openshift Enterprise 3.4 and for Openshift Origin 1.3 and 1.4, the Contiv installer is available in the Openshift Ansible github repo master branch and hence may be installed by pulling the Openshift Ansible installer from github directly. An example of this installation is provided below.
+1. The currently recommended combination is to use Openshift (Origin or Enterprise) version 3.6 or later and Contiv in L3 VXLAN mode without BGP. Earlier versions of Openshift or other networking modes of Contiv can also work but will require some additional manual configuration changes to the physical networking layer and/or the Openshift/ kubernetes layer. Note that the Openshift 3.6 Ansible installer can also be used to deploy Openshift packages from earlier releases by simply setting the openshift_release configuration variable in the ansible installer inventory file as shown in the examples below.  
 
-## Installation example for Openshift + Contiv
+## Installation example for Openshift + Contiv (L3 VXLAN mode use case)
+In this example, we shall illustrate a single combined installation of Openshift and Contiv together and shall use Contiv in L3 VXLAN mode (which is currently the recommended mode for Contiv). This example deploys these on top of a cluster of Virtual Machines (that have been pre-created on some standard IaaS service such as Openstack for example) but this combination is also supported when the cluster hosts are bare metal machines.
 
-In this example, we shall illustrate a single combined installation of Openshift and Contiv together and shall use the Openshift Ansible directly from github to do this. In this example, we have an Ansible installer/ management node installing Openshift + Contiv onto 4 bare metal servers resulting in 1 Master + 3 Nodes in the resulting Openshift cluster. 
+1. Clone the standard Openshift Ansible repo directly from a supported release branch  
+(*git clone -b release-3.6 https://github.com/openshift/openshift-ansible.git*)  
+**Note:** Alternately the Openshift Ansible can also be installed via yum/ RPM (refer to Openshift documentation for details on using the *atomic-openshift-utils* rpm package for this)  or git cloned from the master branch, instead of the release-3.6 branch, from the same repo.
+2. Edit the ansible inventory file to match the desired master and node topology and IP addresses of your target bare metal machines. The Openshift documentation (see for example [here](https://docs.openshift.org/latest/install_config/install/advanced_install.html) and [here](https://docs.openshift.com/container-platform/3.6/install_config/install/advanced_install.html)) has examples of Ansible inventory files for typical cluster deployments.
+3. Edit the ansible inventory file to use Contiv as the networking plugin instead of the default Openshift SDN and set additional configuration parameters to match your cluster topology and contiv network settings. (an example of the Contiv configuration parameters is provided below).
+4. Run the Ansible playbook for the BYO machines case  
+*ansible-playbook -i your_inventory_file ./playbooks/BYO/config.yml*
 
-1. Clone the standard Openshift Ansible repo directly (git clone https://github.com/openshift/openshift-ansible.git)
-2. Edit the ansible inventory file to match the desired master and node topology and IP addresses of your target bare metal machines. The Openshift documentation (see for example [here](https://docs.openshift.org/latest/install_config/install/advanced_install.html) and [here](https://docs.openshift.com/container-platform/3.4/install_config/install/advanced_install.html)) has examples of Ansible inventory files for typical cluster deployments.
+## Example Ansible inventory file Openshift Origin + Contiv (L3 VXLAN mode) on VMs
+Please refer to the [Openshift documentation](https://docs.openshift.org/latest/install_config/install/advanced_install.html) for full details on Openshift configuration. The example ansible inventory file here is to install a cluster of 3 Openshift Origin v3.6 nodes running Contiv in L3 VXLAN mode and deployed on top of 3 VMs. Each of these VMs has a private IP and a floating IP (in Openstack terminology). In the example below, the addresses in the range 184.94.x.x are the floating IP addresses of the cluster VMs and the addresses in the range 10.104.x.x are the private IP addresses of the cluster VMs. Please modify these to match the private IP and floating IP addresses in your set of VMs accordingly before running the playbook. 
+
+```
+# Create an OSEv3 group that contains the masters and nodes groups
+[OSEv3:children]
+masters
+nodes
+
+# Set variables common for all OSEv3 hosts
+[OSEv3:vars]
+# SSH user, this user should allow ssh based auth without requiring a password
+ansible_ssh_user=cloud
+
+# Temporarily disable resource checks to allow test deployment on low resource hosts/ VMs 
+openshift_disable_check=disk_availability,memory_availability,docker_storage
+
+# If ansible_ssh_user is not root, ansible_become must be set to true
+ansible_become=true
+
+deployment_type=origin
+
+# To try other release versions, change this variable (v3.6 is currently the recommended release)
+#openshift_release=v1.5
+openshift_release=v3.6
+
+os_firewall_use_firewalld=false
+
+openshift_use_openshift_sdn=False
+openshift_use_contiv=True
+os_sdn_network_plugin_name='cni'
+
+# Use the following contiv settings for now. 
+# In upcoming versions of the installer, these settings will be automatically defaulted and hence not needed to be configured explicitly here
+netplugin_interface=eth0
+netmaster_interface=eth0
+netplugin_fwd_mode=routing
+contiv_encap_mode=vxlan
+contiv_default_network_tag=1000
+
+# host group for masters
+[masters]
+184.94.251.61 openshift_public_hostname=184.94.251.61
+
+# host group for nodes, includes region info
+[nodes]
+184.94.251.61 netplugin_ctrl_ip=10.104.1.80 openshift_public_hostname=184.94.251.61 openshift_node_labels="{'region': 'infra', 'zone': 'default'}" openshift_schedulable=true
+184.94.253.153 netplugin_ctrl_ip=10.104.1.83 openshift_public_hostname=184.94.253.153 openshift_node_labels="{'region': 'primary', 'zone': 'east'}" openshift_schedulable=true
+184.94.251.16 netplugin_ctrl_ip=10.104.1.84 openshift_public_hostname=184.94.251.16 openshift_node_labels="{'region': 'primary', 'zone': 'west'}" openshift_schedulable=true
+```
+
+## Cleaning up/ uninstalling an Openshift + Contiv cluster
+
+You may sometimes need to do a clean rebuild of an Openshift + Contiv cluster. This may be because of an error in a prior deployment attempt that may have left some unknown/ partial state on the host machines or when you are switching from another network plugin type to Contiv for example. In all such cases, it is strongly recommended 
+clean up the cluster hosts and remove any left over state that may exist on the hosts. Without proper cleanup/ uninstall of prior state, it is possible to have errors in new attempts to deploy Openshift + Contiv on the same hosts. In order to uninstall Contiv and Openshift, run the following two ansible playbooks
+
+1. *ansible-playbook -i your_inventory_file ./playbooks/adhoc/contiv/delete_contiv.yml*
+2. *ansible-playbook -i your_inventory_file ./playbooks/adhoc/uninstall.yml*
+
+After these steps, the hosts will be cleaned up from any left over state and a new Openshift + Contiv cluster may safely be installed on these hosts using an install process such as described in the earlier example. 
+
+## Installation example for Openshift + Contiv (L2 VLAN mode use case)
+
+In this second example, we shall illustrate a single combined installation of Openshift and Contiv together and shall use the Openshift Ansible directly from github to do this. In this example, we have an Ansible installer/ management node installing Openshift + Contiv onto 4 bare metal servers resulting in 1 Master + 3 Nodes in the resulting Openshift cluster. 
+
+1. Clone the standard Openshift Ansible repo directly (*git clone https://github.com/openshift/openshift-ansible.git*)
+2. Edit the ansible inventory file to match the desired master and node topology and IP addresses of your target bare metal machines. The Openshift documentation (see for example [here](https://docs.openshift.org/latest/install_config/install/advanced_install.html) and [here](https://docs.openshift.com/container-platform/3.6/install_config/install/advanced_install.html)) has examples of Ansible inventory files for typical cluster deployments.
 3. Edit the ansible inventory file to use Contiv as the networking plugin instead of the default Openshift SDN and set additional configuration parameters to match your cluster topology and contiv network settings. (an example of the Contiv configuration parameters is in the following section).
-4. Run the Ansible playbook for the BYO machines case (i.e. "ansible-playbook -i <your_inventory_file> ./playbooks/BYO/config.yml").
+4. Run the Ansible playbook for the BYO machines case  
+*ansible-playbook -i your_inventory_file ./playbooks/BYO/config.yml*
 
 Thats it, you now have a running Openshift cluster which uses Contiv as its networking layer.
 
-**Note:** Ansible 2.2.0 or later is recommended for deploying via the Openshift + Contiv Ansible playbook.
+## Example Ansible inventory file for deploying Openshift Origin + Contiv (L2 VLAN mode) on Bare Metal servers
 
-## Example Ansible inventory file for deploying Openshift Origin + Contiv
-
-Please refer to the [Openshift documentation](https://docs.openshift.org/latest/install_config/install/advanced_install.html) for full details on Openshift configuration. Here we list an example of adapting one of the inventory files from the Openshift documentation examples to substitute Contiv in place of the default Openshift SDN. This example illustrates set up for an Openshift Origin cluster running version 1.4.1. Contiv is enabled via the variable "openshift_use_contiv" and by setting "openshift_use_openshift_sdn" to "false" as well as other parameters as shown below. "netplugin_interface" is the contiv data plane vlan interface, "netmaster_interface" is the control plane interface, "netplugin_fwd_interface" set to "bridge" sets Contiv in L2 vlan mode. The default subnet (for pod IPs), default gateway and VLAN tag are set via  "contiv_default_subnet", "contiv_default_gw" and "contiv_default_network_tag".  When this playbook is executed, a default container network (called "default-net") will also be set up and will use these parameters. Note that since this is the L2 VLAN mode of Contiv, the data plane VLANs and default gateway will also need to be setup externally in the physical network that the cluster uses. 
+Please refer to the [Openshift documentation](https://docs.openshift.org/latest/install_config/install/advanced_install.html) for full details on Openshift configuration. Here we list an example of adapting one of the inventory files from the Openshift documentation examples to substitute Contiv in place of the default Openshift SDN. This example illustrates set up for an Openshift Origin cluster running version 3.6. Contiv is enabled via the variable "openshift_use_contiv" and by setting "openshift_use_openshift_sdn" to "false" as well as other parameters as shown below. "netplugin_interface" is the contiv data plane vlan interface, "netmaster_interface" is the control plane interface, "netplugin_fwd_interface" set to "bridge" sets Contiv in L2 vlan mode. The default subnet (for pod IPs), default gateway and VLAN tag are set via  "contiv_default_subnet", "contiv_default_gw" and "contiv_default_network_tag".  When this playbook is executed, a default container network (called "default-net") will also be set up and will use these parameters. Note that since this is the L2 VLAN mode of Contiv, the data plane VLANs and default gateway will also need to be setup externally in the physical network that the cluster uses. 
 
 ```
 # Create an OSEv3 group that contains the masters and nodes groups
@@ -64,8 +136,7 @@ ansible_become=true
 
 deployment_type=origin
 
-openshift_version=1.4.1
-openshift_release=v1.4
+openshift_release=v3.6
 
 os_firewall_use_firewalld=false
 
@@ -80,5 +151,6 @@ contiv_default_subnet="29.70.0.0/24"
 contiv_default_gw="29.70.0.1"
 contiv_default_network_tag="2970"
 
+# rest of the file similar to the example listed above for the L3 VXLAN mode case
 ```
 


### PR DESCRIPTION
Contiv web site/ doc updates for Openshift section. Add details on latest features and support with Openshift v3.6. Add deployment examples for L3 VXLAN mode of Contiv. Plus other misc cleanup.