### PR TITLE
Updated prometheus docs with contiv 1.2.0 steps

### DIFF
--- a/documents/tutorials/prometheus-tutorial.html
+++ b/documents/tutorials/prometheus-tutorial.html
@@ -248,28 +248,57 @@ GitHub</a></li>
 <h3><a name="setup"></a> Setup</h3>
 <p>Please finish the <a href="/documents/tutorials/networking-kubernetes-16.html">Container Networking Tutorial</a>, but do not clean up your cluster.</p>
 <p>In order to install Prometheus and Grafana, please follow these steps.</p>
-<pre class="highlight plaintext"><code>[vagrant@kubeadm-master ~]$ cd contiv-*
-[vagrant@kubeadm-master contiv-1.1.1]$  cd install/k8s/k8s1.6
-[vagrant@kubeadm-master k8s1.6]$ sudo -i
-[root@kubeadm-master k8s1.6]# cp prometheus.yml /var/contiv/prometheus.yml
-[root@kubeadm-master k8s1.6]# exit
+<pre class="highlight plaintext"><code>$ cd install/cluster/
+$ vagrant ssh kubeadm-master
+[vagrant@kubeadm-master ~]$ cd contiv-*
+[vagrant@kubeadm-master contiv-1.2.0]$ cd install/k8s/configs/
+[vagrant@kubeadm-master configs]$ pwd
+/home/vagrant/contiv-1.2.0/install/k8s/configs
+[vagrant@kubeadm-master configs]$ sudo -i
+[root@kubeadm-master ~]# cd /home/vagrant/contiv-1.2.0/install/k8s/configs
+[root@kubeadm-master configs]# cp prometheus.yml /var/contiv/prometheus.yml
+[root@kubeadm-master configs]# exit
 exit
 </code></pre>
-<pre class="highlight plaintext"><code>[vagrant@kubeadm-master k8s1.6]$ kubectl create -f contiv-prometheus.yml
+<pre class="highlight plaintext"><code>[vagrant@kubeadm-master configs]$  kubectl create -f contiv-prometheus.yml
 clusterrole "prometheus" created
 serviceaccount "prometheus" created
 clusterrolebinding "prometheus" created
 replicaset "contiv-prometheus" created
 service "prometheus" created
 
-[vagrant@kubeadm-master k8s1.6]$ kubectl create -f contiv-grafana.yml
+[vagrant@kubeadm-master configs]$ kubectl create -f contiv-grafana.yml
 clusterrole "grafana" created
 serviceaccount "grafana" created
 clusterrolebinding "grafana" created
 replicaset "contiv-grafana" created
 service "grafana" created
 
-[vagrant@kubeadm-master k8s1.6]$ cd
+[vagrant@kubeadm-master configs]$ cd
+</code></pre>
+<p>Check if Contiv&#39;s <code>stats_exporter</code> is running as a sidecar container in the netmaster and netplugin kubernetes pods.</p>
+<pre class="highlight plaintext"><code>[vagrant@kubeadm-master configs]$ kubectl get pods -n=kube-system | grep 'netplugin\|netmaster'
+contiv-netmaster-425jp                   3/3       Running   0          2d
+contiv-netplugin-75dxx                   2/2       Running   0          2d
+contiv-netplugin-zhbrd                   2/2       Running   0          2d
+
+[vagrant@kubeadm-master configs]$ kubectl describe pod -n=kube-system contiv-netmaster-425jp | grep stats
+    Image:          contiv/stats
+    Image ID:       docker-pullable://docker.io/contiv/stats@sha256:9dc89b719703cfbd5f3459a4976336c42d470e9eaa9769de647c1ce3486f8e8b
+
+[vagrant@kubeadm-master configs]$ kubectl describe pod -n=kube-system contiv-netplugin-75dxx | grep stats
+    Image:          contiv/stats
+    Image ID:       docker-pullable://docker.io/contiv/stats@sha256:9dc89b719703cfbd5f3459a4976336c42d470e9eaa9769de647c1ce3486f8e8b
+
+[vagrant@kubeadm-master configs]$ kubectl describe pod -n=kube-system contiv-netplugin-zhbrd | grep stats
+    Image:          contiv/stats
+    Image ID:       docker-pullable://docker.io/contiv/stats@sha256:9dc89b719703cfbd5f3459a4976336c42d470e9eaa9769de647c1ce3486f8e8b
+</code></pre>
+<p>Check if <code>stats_exporter</code> exposes metrics for Prometheus to scrape.</p>
+<pre class="highlight plaintext"><code>[vagrant@kubeadm-master configs]$ curl localhost:9004/metrics
+
+[vagrant@kubeadm-master configs]$ curl localhost:9005/metrics
+
 </code></pre>
 
 <h3><a name="ch1"></a> Chapter 1: Prometheus and Grafana</h3>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,361 +2,361 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>http://contiv.io/articles/2016/03/06/scaling-microservices.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/articles/2016/05/17/onug-contiv-award.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/articles/2016/07/13/dockercon-talk.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/articles/</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/admin/createNodes.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/admin/createTenant.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/admin/</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/admin/manageAuthorizations.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/admin/manageLDAP.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/admin/manageNetworks.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/admin/manageUsers.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/api/contiv.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/api/wip.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/community/CONTRIBUTING.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/community/examples.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/community/GOVERNANCE-corenetworking.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/community/GOVERNANCE-deployment.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/community/GOVERNANCE-docs.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/community/GOVERNANCE-tools.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/community/GOVERNANCE-ui-authproxy.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/community/GOVERNANCE.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/community/</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/demos/</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/gettingStarted/</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/networking/aci_setup.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/networking/aci_ug.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/networking/bgp.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/networking/concepts.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/networking/features.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/networking/</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/networking/ipam.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/networking/ipv6.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/networking/l2-vlan.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/networking/physical-networks.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/networking/policies.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/networking/portinfo.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/networking/services.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/openshift/</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/reference/netctlcli.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/releasenotes/beta.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/releasenotes/v10x.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/releasenotes/v11x.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/releasenotes/v12x.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/samples/mcast.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/support/</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/support/supportmatrix/</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/support/supportmatrix/v10x.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/support/supportmatrix/v11x.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/support/supportmatrix/v12x.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/talks/</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/tutorials/container-101.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/tutorials/contiv-compose.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/tutorials/contiv-policy-kubernetes-16.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/tutorials/contiv-policy.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/tutorials/</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/tutorials/networking-kubernetes-16.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/tutorials/prometheus-tutorial.html</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>http://contiv.io/documents/samples/</loc>
-    <lastmod>2017-12-15T00:00:00+00:00</lastmod>
+    <lastmod>2017-12-20T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/websrc/source/documents/tutorials/prometheus-tutorial.md
+++ b/websrc/source/documents/tutorials/prometheus-tutorial.md
@@ -25,29 +25,64 @@ Please finish the [Container Networking Tutorial](/documents/tutorials/networkin
 In order to install Prometheus and Grafana, please follow these steps.
 
 ```
+$ cd install/cluster/
+$ vagrant ssh kubeadm-master
 [vagrant@kubeadm-master ~]$ cd contiv-*
-[vagrant@kubeadm-master contiv-1.1.1]$  cd install/k8s/k8s1.6
-[vagrant@kubeadm-master k8s1.6]$ sudo -i
-[root@kubeadm-master k8s1.6]# cp prometheus.yml /var/contiv/prometheus.yml
-[root@kubeadm-master k8s1.6]# exit
+[vagrant@kubeadm-master contiv-1.2.0]$ cd install/k8s/configs/
+[vagrant@kubeadm-master configs]$ pwd
+/home/vagrant/contiv-1.2.0/install/k8s/configs
+[vagrant@kubeadm-master configs]$ sudo -i
+[root@kubeadm-master ~]# cd /home/vagrant/contiv-1.2.0/install/k8s/configs
+[root@kubeadm-master configs]# cp prometheus.yml /var/contiv/prometheus.yml
+[root@kubeadm-master configs]# exit
 exit
 ```
 ```
-[vagrant@kubeadm-master k8s1.6]$ kubectl create -f contiv-prometheus.yml
+[vagrant@kubeadm-master configs]$  kubectl create -f contiv-prometheus.yml
 clusterrole "prometheus" created
 serviceaccount "prometheus" created
 clusterrolebinding "prometheus" created
 replicaset "contiv-prometheus" created
 service "prometheus" created
 
-[vagrant@kubeadm-master k8s1.6]$ kubectl create -f contiv-grafana.yml
+[vagrant@kubeadm-master configs]$ kubectl create -f contiv-grafana.yml
 clusterrole "grafana" created
 serviceaccount "grafana" created
 clusterrolebinding "grafana" created
 replicaset "contiv-grafana" created
 service "grafana" created
 
-[vagrant@kubeadm-master k8s1.6]$ cd
+[vagrant@kubeadm-master configs]$ cd
+```
+
+Check if Contiv's `stats_exporter` is running as a sidecar container in the netmaster and netplugin kubernetes pods.
+
+```
+[vagrant@kubeadm-master configs]$ kubectl get pods -n=kube-system | grep 'netplugin\|netmaster'
+contiv-netmaster-425jp                   3/3       Running   0          2d
+contiv-netplugin-75dxx                   2/2       Running   0          2d
+contiv-netplugin-zhbrd                   2/2       Running   0          2d
+
+[vagrant@kubeadm-master configs]$ kubectl describe pod -n=kube-system contiv-netmaster-425jp | grep stats
+    Image:          contiv/stats
+    Image ID:       docker-pullable://docker.io/contiv/stats@sha256:9dc89b719703cfbd5f3459a4976336c42d470e9eaa9769de647c1ce3486f8e8b
+
+[vagrant@kubeadm-master configs]$ kubectl describe pod -n=kube-system contiv-netplugin-75dxx | grep stats
+    Image:          contiv/stats
+    Image ID:       docker-pullable://docker.io/contiv/stats@sha256:9dc89b719703cfbd5f3459a4976336c42d470e9eaa9769de647c1ce3486f8e8b
+
+[vagrant@kubeadm-master configs]$ kubectl describe pod -n=kube-system contiv-netplugin-zhbrd | grep stats
+    Image:          contiv/stats
+    Image ID:       docker-pullable://docker.io/contiv/stats@sha256:9dc89b719703cfbd5f3459a4976336c42d470e9eaa9769de647c1ce3486f8e8b
+```
+
+Check if `stats_exporter` exposes metrics for Prometheus to scrape.
+
+```
+[vagrant@kubeadm-master configs]$ curl localhost:9004/metrics
+
+[vagrant@kubeadm-master configs]$ curl localhost:9005/metrics
+
 ```
 
 ### <a name="ch1"></a> Chapter 1: Prometheus and Grafana


### PR DESCRIPTION
Updated prometheus docs with contiv 1.2.0 steps. They will be live at http://contiv.github.io/documents/tutorials/prometheus-tutorial.html.

Tested per the steps in https://github.com/contiv/contiv.github.io/blob/master/CONTRIBUTING.md#running-the-site-locally-and-testing-your-changes.

Signed-off-by: Vikram Hosakote <vhosakot@cisco.com>